### PR TITLE
This fixes the issue of multiple creation of unsupported.txt file,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - pip install codecov
   - pip install nose-cov
   - pip install nose-exclude
+  - pip install appdirs
 # command to run tests
 script:
   - export TESTING=True

--- a/swaglyrics/__main__.py
+++ b/swaglyrics/__main__.py
@@ -4,6 +4,8 @@ import webbrowser
 import threading
 import requests
 import time
+import platform
+from appdirs import AppDirs
 from swaglyrics.cli import lyrics, clear
 from swaglyrics import spotify
 from swaglyrics.tab import app
@@ -19,7 +21,19 @@ def main():
 	#                     |___/      |___/
 	# 	""")
 	print('Updating unsupported.txt from server.')
-	with open('unsupported.txt', 'w', encoding='utf-8') as f:
+
+	appDataDir = AppDirs('swaglyrics', os.getlogin()).user_config_dir
+
+	if platform.system() == "Windows":
+		if not os.path.exists("C:\\Users\\"+os.getlogin()+"\\AppData\\Local\\swaglyrics\\"):
+			os.makedirs("C:\\Users\\"+os.getlogin()+"\\AppData\\Local\\swaglyrics\\")                
+		
+		appDataDir = "C:\\Users\\"+os.getlogin()+"\\AppData\\Local\\swaglyrics\\"
+		print (appDataDir)
+	else:
+		appDataDir = appDataDir+"/"
+
+	with open(appDataDir+"unsupported.txt",'w', encoding='utf-8') as f:
 		response = requests.get('http://aadibajpai.pythonanywhere.com/master_unsupported')
 		f.write(response.text)
 	print("Updated unsupported.txt successfully.")
@@ -63,7 +77,7 @@ def main():
 				exit()
 			if os.environ.get("TESTING", "False") != "False":
 				break
-
+	
 	else:
 		parser.print_help()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,8 @@ Contains unit tests for cli.py
 import unittest
 from swaglyrics.cli import stripper, lyrics, get_lyrics, clear
 from mock import mock, patch
+from appdirs import  AppDirs
+import platform
 import os
 import requests
 
@@ -21,6 +23,15 @@ class Tests(unittest.TestCase):
 	"""
 	Unit tests
 	"""
+
+	appDataDir = AppDirs('swaglyrics', os.getlogin()).user_config_dir
+	if platform.system() == "Windows":
+		if not os.path.exists("C:\\Users\\"+os.getlogin()+"\\AppData\\Local\\swaglyrics\\"):
+			os.makedirs("C:\\Users\\"+os.getlogin()+"\\AppData\\Local\\swaglyrics\\")
+		appDataDir = "C:\\Users\\"+os.getlogin()+"\\AppData\\Local\\swaglyrics\\"
+	
+	else:
+		appDataDir = appDataDir + "/"
 
 	def setup(self):
 		pass
@@ -66,9 +77,9 @@ class Tests(unittest.TestCase):
 		self.assertEqual(get_lyrics("Battle Symphony", "Drake", False), "Couldn't get lyrics for Battle Symphony by Drake.\n")
 
 		# Deleting above songs and artists from unsupported.txt
-		with open("unsupported.txt", "r") as f:
+		with open(appDataDir+"unsupported.txt", "r") as f:
 			lines = f.readlines()
-		with open("unsupported.txt", "w") as f:
+		with open(appDataDir+"unsupported.txt", "w") as f:
 			for line in lines:
 				if line not in [" Battle Symphony by One Direction \n", " Faded by Muhmello \n", " Battle Symphony by Drake \n"]:
 					f.write(line)
@@ -85,9 +96,9 @@ class Tests(unittest.TestCase):
 		self.assertEqual(lyrics("Fantastic", "Beasts"), "Lyrics unavailable for Fantastic by Beasts.\n")
 
 		# Deleting above songs and artists from unsupported.txt
-		with open("unsupported.txt", "r") as f:
+		with open(appDataDir+"unsupported.txt", "r") as f:
 			lines = f.readlines()
-		with open("unsupported.txt", "w") as f:
+		with open(appDataDir+"unsupported.txt", "w") as f:
 			for line in lines:
 				if line not in [" Hello by World \n", " Foo by Bar \n", " Fantastic by Beasts \n"]:
 					f.write(line)
@@ -104,7 +115,7 @@ class Tests(unittest.TestCase):
 		"""
 		test that lyrics function does not break if unsupported.txt is not found
 		"""
-		os.rename("unsupported.txt", "unsupported2.txt")
+		os.rename(appDataDir+"unsupported.txt", appDataDir+"unsupported2.txt")
 		self.assertEqual(lyrics("Crimes", "Grindelwald", False), "Couldn\'t get lyrics for Crimes by Grindelwald.\n")
 
 	def test_database_for_unsupported_song(self):

--- a/unsupported.txt
+++ b/unsupported.txt
@@ -124,3 +124,8 @@ VENGEANCE | VENGEANCE [FEAT. JPEGMAFIA & ZILLAKAMI | JPEGMAF1A + Z1LLAKAM1] by D
 1000 Dreams by DJ Bobo
 Like This (The Sequel) by Technotronic
 Bhare Bazaar by Rishi Rich
+The Wanderer Between Life and Death by Arts Of Erebus 
+Bhole Baba by Laman 
+Piya Na Jaa by Laman 
+Bandeya by Laman 
+Raaviye by Laman 


### PR DESCRIPTION
This creates the file in appdata folder and can't write in the site package because it will need sudo access. I have used appdirs module which fetches appdata location platform independently. For path I have used string concatenation because of os.path.join() can't take 3 arguments.

![duplicate unsupported file fix](https://user-images.githubusercontent.com/25477918/55234121-6c56cd00-5250-11e9-9927-e15f559aea6f.gif)
