### PR TITLE
[FIX] Stop empty stripped song names from getting returned

### DIFF
--- a/swaglyrics/cli.py
+++ b/swaglyrics/cli.py
@@ -65,9 +65,8 @@ def get_lyrics(song, artist):
 	:return: song lyrics or None if lyrics unavailable
 	"""
 	url_data = stripper(song, artist)  # generate url path using stripper()
-	if url_data.startswith('-') or \
-			url_data.endswith('-'):  # url path had either song in non-latin, artist in non-latin, or both
-		return None
+	if url_data.startswith('-') or url_data.endswith('-'):
+		return None  # url path had either song in non-latin, artist in non-latin, or both
 	url = f'https://genius.com/{url_data}-lyrics'  # format the url with the url path
 	try:
 		page = requests.get(url)
@@ -87,7 +86,7 @@ def get_lyrics(song, artist):
 	return lyrics
 
 
-def lyrics(song: str, artist: str, make_issue: bool = False) -> str:
+def lyrics(song: str, artist: str, make_issue: bool = True) -> str:
 	"""
 	Displays the fetched lyrics if song playing and handles if lyrics unavailable.
 	:param song: currently playing song
@@ -107,7 +106,7 @@ def lyrics(song: str, artist: str, make_issue: bool = False) -> str:
 	if not lyrics:
 		lyrics = f"Couldn't get lyrics for {song} by {artist}.\n"
 		# Log song and artist for which lyrics couldn't be obtained
-		with open(unsupported_txt, mode='a', encoding='utf-8') as f:
+		with open(unsupported_txt, 'a', encoding='utf-8') as f:
 			f.write(f'{song} by {artist} \n')
 			f.close()
 		if make_issue:

--- a/swaglyrics/cli.py
+++ b/swaglyrics/cli.py
@@ -33,6 +33,8 @@ def stripper(song: str, artist: str) -> str:
 	:return: formatted url path
 	"""
 	song = re.sub(brc, '', song).strip()  # remove braces and included text with feat and text after '- '
+	if not re.sub(nlt, '', song):  # check if title contains strictly non-latin characters
+		return None
 	ft = wth.search(song)  # find supporting artists if any
 	if ft:
 		song = song.replace(ft.group(), '')  # remove (with supporting artists) from song
@@ -65,6 +67,8 @@ def get_lyrics(song, artist):
 	:return: song lyrics or None if lyrics unavailable
 	"""
 	url_data = stripper(song, artist)  # generate url path using stripper()
+	if url_data is None:  # url path returned none, pass it along
+		return None
 	url = f'https://genius.com/{url_data}-lyrics'  # format the url with the url path
 	try:
 		page = requests.get(url)

--- a/swaglyrics/cli.py
+++ b/swaglyrics/cli.py
@@ -1,3 +1,4 @@
+import io
 import requests
 import re
 import os
@@ -108,7 +109,7 @@ def lyrics(song: str, artist: str, make_issue: bool = True) -> str:
 	if not lyrics:
 		lyrics = f"Couldn't get lyrics for {song} by {artist}.\n"
 		# Log song and artist for which lyrics couldn't be obtained
-		with open(unsupported_txt, 'a') as f:
+		with io.open(unsupported_txt, mode='a', encoding='utf-8') as f:
 			f.write(f'{song} by {artist} \n')
 			f.close()
 		if make_issue:

--- a/swaglyrics/cli.py
+++ b/swaglyrics/cli.py
@@ -1,4 +1,3 @@
-import io
 import requests
 import re
 import os
@@ -34,8 +33,6 @@ def stripper(song: str, artist: str) -> str:
 	:return: formatted url path
 	"""
 	song = re.sub(brc, '', song).strip()  # remove braces and included text with feat and text after '- '
-	if not re.sub(nlt, '', song):  # check if title contains strictly non-latin characters
-		return None
 	ft = wth.search(song)  # find supporting artists if any
 	if ft:
 		song = song.replace(ft.group(), '')  # remove (with supporting artists) from song
@@ -68,7 +65,8 @@ def get_lyrics(song, artist):
 	:return: song lyrics or None if lyrics unavailable
 	"""
 	url_data = stripper(song, artist)  # generate url path using stripper()
-	if url_data is None:  # url path returned none, pass it along
+	if url_data.startswith('-') or \
+			url_data.endswith('-'):  # url path had either song in non-latin, artist in non-latin, or both
 		return None
 	url = f'https://genius.com/{url_data}-lyrics'  # format the url with the url path
 	try:
@@ -89,7 +87,7 @@ def get_lyrics(song, artist):
 	return lyrics
 
 
-def lyrics(song: str, artist: str, make_issue: bool = True) -> str:
+def lyrics(song: str, artist: str, make_issue: bool = False) -> str:
 	"""
 	Displays the fetched lyrics if song playing and handles if lyrics unavailable.
 	:param song: currently playing song
@@ -109,7 +107,7 @@ def lyrics(song: str, artist: str, make_issue: bool = True) -> str:
 	if not lyrics:
 		lyrics = f"Couldn't get lyrics for {song} by {artist}.\n"
 		# Log song and artist for which lyrics couldn't be obtained
-		with io.open(unsupported_txt, mode='a', encoding='utf-8') as f:
+		with open(unsupported_txt, mode='a', encoding='utf-8') as f:
 			f.write(f'{song} by {artist} \n')
 			f.close()
 		if make_issue:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ class Tests(unittest.TestCase):
 		self.assertEqual(stripper('Seasons (with Sjava & Reason)', 'Mozzy'), 'Mozzy-Sjava-and-Reason-Seasons')
 		self.assertEqual(stripper(
 			'거품 안 넘치게 따라줘 [Life Is Good] (feat. Crush, Dj Friz)', 'Dynamic Duo'), 'Dynamic-Duo-Life-Is-Good')
+		self.assertEqual(stripper('ハゼ馳せる果てるまで', 'ZUTOMAYO'), None)
 		self.assertEqual(stripper('Ice Hotel (ft. SZA)', 'XXXTENTACION'), 'XXXTENTACION-Ice-Hotel')
 
 	# Integration test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,6 @@ class Tests(unittest.TestCase):
 		self.assertEqual(stripper('Seasons (with Sjava & Reason)', 'Mozzy'), 'Mozzy-Sjava-and-Reason-Seasons')
 		self.assertEqual(stripper(
 			'거품 안 넘치게 따라줘 [Life Is Good] (feat. Crush, Dj Friz)', 'Dynamic Duo'), 'Dynamic-Duo-Life-Is-Good')
-		self.assertEqual(stripper('ハゼ馳せる果てるまで', 'ZUTOMAYO'), None)
 		self.assertEqual(stripper('Ice Hotel (ft. SZA)', 'XXXTENTACION'), 'XXXTENTACION-Ice-Hotel')
 
 	# Integration test
@@ -44,6 +43,9 @@ class Tests(unittest.TestCase):
 		"""
 		Test that get_lyrics function works
 		"""
+		self.assertEqual(get_lyrics('果てるまで', 'ハゼ馳せる'), None)  # song and artist non-latin
+		self.assertEqual(get_lyrics('Hello', 'ハゼ馳せる'), None)  # artist non-latin
+		self.assertEqual(get_lyrics('ハゼ馳せる果てるまで', 'ZUTOMAYO'), None)  # song non-latin
 		self.assertEqual(get_lyrics("Faded", "Alan Walker")[:9], "[Verse 1]")
 		self.assertEqual(get_lyrics("Radioactive", "Imagine Dragons")[:7], "[Intro]")
 		self.assertEqual(get_lyrics("Battle Symphony", "Linkin Park")[:9], "[Verse 1]")


### PR DESCRIPTION
**[FIX]** for #1896

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/SwagLyrics/SwagLyrics-For-Spotify/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [x] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

This fix prevents songs with only non-Latin characters in the title from being passed ahead. The query is terminated and the song shows up as unsupported instead.
