### PR TITLE
[IMPROVEMENT] Create unsupported.txt in OS specific user data folder

### DIFF
--- a/swaglyrics/__init__.py
+++ b/swaglyrics/__init__.py
@@ -40,7 +40,7 @@ genius_timeout = 20
 unsupported_txt = user_data_dir("unsupported.txt")
 
 # create unsupported.txt if it doesn't exist
-unsupported_txt.mkdir(parents=True, exist_ok=True)
+unsupported_txt.touch(exist_ok=True)
 
 
 class SameSongPlaying(Exception):

--- a/swaglyrics/__init__.py
+++ b/swaglyrics/__init__.py
@@ -40,6 +40,7 @@ genius_timeout = 20
 unsupported_txt = user_data_dir("unsupported.txt")
 
 # create unsupported.txt if it doesn't exist
+unsupported_txt.parent.mkdir(parents=True, exist_ok=True)
 unsupported_txt.touch(exist_ok=True)
 
 

--- a/swaglyrics/__init__.py
+++ b/swaglyrics/__init__.py
@@ -7,14 +7,15 @@ from pathlib import Path
 # doc: https://github.com/ActiveState/appdirs/blob/master/appdirs.py#L44 derivative
 def user_data_dir(file_name):
     r"""
-        Return full path to the user-specific data dir for SwagLyrics.
+    Get OS specific data directory path for SwagLyrics.
 
-        :param file_name: file to be fetched from the data dir
-        Typical user data directories are:
-            macOS:    ~/Library/Application Support/SwagLyrics
-            Unix:     ~/.local/share/SwagLyrics   # or in $XDG_DATA_HOME, if defined
-            Win 10:   C:\Users\<username>\AppData\Local\SwagLyrics
-        For Unix, we follow the XDG spec and support $XDG_DATA_HOME if defined.
+    Typical user data directories are:
+        macOS:    ~/Library/Application Support/SwagLyrics
+        Unix:     ~/.local/share/SwagLyrics   # or in $XDG_DATA_HOME, if defined
+        Win 10:   C:\Users\<username>\AppData\Local\SwagLyrics
+    For Unix, we follow the XDG spec and support $XDG_DATA_HOME if defined.
+    :param file_name: file to be fetched from the data dir
+    :return: full path to the user-specific data dir
     """
     # get os specific path
     if sys.platform.startswith("win"):

--- a/swaglyrics/__init__.py
+++ b/swaglyrics/__init__.py
@@ -1,12 +1,43 @@
-import os
+import sys
+from os import getenv
+from pathlib import Path
+
+
+# create unsupported.txt in os specific user directory
+# doc: https://github.com/ActiveState/appdirs/blob/master/appdirs.py#L44 derivative
+def user_data_dir(file_name):
+    r"""
+        Return full path to the user-specific data dir for SwagLyrics.
+
+        :param file_name: file to be fetched from the data dir
+        Typical user data directories are:
+            macOS:    ~/Library/Application Support/SwagLyrics
+            Unix:     ~/.local/share/SwagLyrics   # or in $XDG_DATA_HOME, if defined
+            Win 10:   C:\Users\<username>\AppData\Local\SwagLyrics
+        For Unix, we follow the XDG spec and support $XDG_DATA_HOME if defined.
+    """
+    # get os specific path
+    if sys.platform.startswith("win"):
+        os_path = getenv("LOCALAPPDATA")
+    elif sys.platform.startswith("darwin"):
+        os_path = "~/Library/Application Support"
+    else:
+        # linux
+        os_path = getenv("XDG_DATA_HOME", "~/.local/share")
+
+    # join with SwagLyrics dir
+    path = Path(os_path) / "SwagLyrics"
+
+    return path.expanduser() / file_name
+
 
 name = 'swaglyrics'
 __version__ = '1.2.0'
-unsupported_txt = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'unsupported.txt')
 backend_url = 'https://api.swaglyrics.dev'
 api_timeout = 10
 genius_timeout = 20
+unsupported_txt = user_data_dir("unsupported.txt")
 
 
 class SameSongPlaying(Exception):
-	pass
+    pass

--- a/swaglyrics/__init__.py
+++ b/swaglyrics/__init__.py
@@ -39,6 +39,9 @@ api_timeout = 10
 genius_timeout = 20
 unsupported_txt = user_data_dir("unsupported.txt")
 
+# create unsupported.txt if it doesn't exist
+unsupported_txt.mkdir(parents=True, exist_ok=True)
+
 
 class SameSongPlaying(Exception):
     pass

--- a/swaglyrics/unsupported.txt
+++ b/swaglyrics/unsupported.txt
@@ -1,1 +1,0 @@
-This will be overwritten on first run, probably.


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/SwagLyrics/SwagLyrics-For-Spotify/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

---

addresses root perms for linux if installed globally, and allows binary creation for different distros.

for windows this is AppData/Local/, linux it is $XDG_DATA_HOME if set otherwise .local/share. and macOS is ~/Library/Application Support.
