### PR TITLE
Run webserver on 0.0.0.0

### DIFF
--- a/swaglyrics/__main__.py
+++ b/swaglyrics/__main__.py
@@ -58,7 +58,7 @@ def show_tab() -> None:
     app.template_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
     app.static_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static')
     port = 5042  # random
-    url = f"http://127.0.0.1:{port}"
+    url = f"http://0.0.0.0:{port}"
     Timer(1.25, open, args=[url]).start()
     app.run(port=port)
 


### PR DESCRIPTION
This is a simple fix to allow webserver access from other devices on the network.

I did have the idea of allowing the IP and port to be set via command line but I don't know python well enough. Another idea I had was to add a headless toggle, meaning it would not open the browser on launch if the toggle was turned on.