### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: poetry install --no-interaction
       - name: Test with pytest
         working-directory: ${{ github.workspace }}
-        run: poetry run pytest --cov-config=.coveragerc --cov-report=xml tests/
+        run: poetry run pytest --cov-config=.coveragerc --cov=swaglyrics --cov-report=xml tests/
       - name: Large Scale Stripper Test Suite
         if: matrix.special
         working-directory: ${{ github.workspace }}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ class Tests(unittest.TestCase):
 		test that lyrics function does not break if unsupported.txt is not found
 		"""
 		fake_get_lyrics.return_value = None
-		os.rename(unsupported_txt, "unsupported2.txt")
+		os.replace(unsupported_txt, "unsupported2.txt")
 		resp = lyrics("Pixel2XL", "Elgoog", False)
 		self.assertEqual(resp, "Couldn't get lyrics for Pixel2XL by Elgoog.\n")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 """
 Contains unit tests for cli.py
 """
-import os
+import shutil
 import unittest
 
 import requests
@@ -85,7 +85,7 @@ class Tests(unittest.TestCase):
 		test that lyrics function does not break if unsupported.txt is not found
 		"""
 		fake_get_lyrics.return_value = None
-		os.replace(unsupported_txt, "unsupported2.txt")
+		shutil.move(unsupported_txt, "unsupported2.txt")
 		resp = lyrics("Pixel2XL", "Elgoog", False)
 		self.assertEqual(resp, "Couldn't get lyrics for Pixel2XL by Elgoog.\n")
 


### PR DESCRIPTION
~~This uses `os.replace` instead of `os.rename` because `os.rename` doesn't work if the file already exists on Windows.~~

The above is a different issue, which also exists, but it is not the cause of the current CI failures. The issue with CI is that it tries to move between drives. Using `shutil.move` fixes both.